### PR TITLE
Avoid extern config

### DIFF
--- a/examples/CBUS_1in1out/CBUS_1in1out.ino
+++ b/examples/CBUS_1in1out/CBUS_1in1out.ino
@@ -207,7 +207,7 @@ void loop() {
   /// check CAN message buffers
   //
 
-  if (CBUS.canp->CBUS.canp->receiveBufferPeakCount() > CBUS.canp->receiveBufferSize()) {
+  if (CBUS.canp->receiveBufferPeakCount() > CBUS.canp->receiveBufferSize()) {
     Serial << F("> receive buffer overflow") << endl;
   }
 
@@ -219,7 +219,8 @@ void loop() {
   /// check CAN bus state
   //
 
-  if ((byte s = CBUS.canp->errorFlagRegister()) != 0) {
+  byte s = CBUS.canp->errorFlagRegister();
+  if (s != 0) {
     Serial << F("> error flag register is non-zero") << endl;
   }
 

--- a/examples/CBUS_empty/CBUS_empty.ino
+++ b/examples/CBUS_empty/CBUS_empty.ino
@@ -181,7 +181,7 @@ void loop() {
   /// check CAN message buffers
   //
 
-  if (CBUS.canp->CBUS.canp->receiveBufferPeakCount() > CBUS.canp->receiveBufferSize()) {
+  if (CBUS.canp->receiveBufferPeakCount() > CBUS.canp->receiveBufferSize()) {
     Serial << F("> receive buffer overflow") << endl;
   }
 
@@ -193,7 +193,8 @@ void loop() {
   /// check CAN bus state
   //
 
-  if ((byte s = CBUS.canp->errorFlagRegister()) != 0) {
+  byte s = CBUS.canp->errorFlagRegister();
+  if (s != 0) {
     Serial << F("> error flag register is non-zero") << endl;
   }
 

--- a/src/CBUS2515.cpp
+++ b/src/CBUS2515.cpp
@@ -51,7 +51,19 @@ ACAN2515 *can;    // CAN bus controller specific object - for MCP2515/25625
 /// constructor
 //
 
-CBUS2515::CBUS2515() {
+CBUS2515::CBUS2515()
+{
+  initMembers();
+}
+
+CBUS2515::CBUS2515(CBUSConfig & config)
+  : CBUSbase(config)
+{
+  initMembers();
+}
+
+void CBUS2515::initMembers()
+{
   _num_rx_buffers = NUM_RX_BUFFS;
   _num_tx_buffers = NUM_TX_BUFFS;
   eventhandler = NULL;

--- a/src/CBUS2515.h
+++ b/src/CBUS2515.h
@@ -63,6 +63,7 @@ class CBUS2515 : public CBUSbase {
 public:
 
   CBUS2515();
+  CBUS2515(CBUSConfig &);
 
   // these methods are declared virtual in the base class and must be implemented by the derived class
   bool begin(bool poll = false, SPIClass spi = SPI);    // note default args
@@ -81,6 +82,7 @@ public:
   ACAN2515 *canp;   // pointer to CAN object so user code can access its members
 
 private:
+  void initMembers();
   unsigned long _osc_freq;
   byte _csPin, _intPin;
   byte _num_rx_buffers, _num_tx_buffers;


### PR DESCRIPTION
Allow creation of CBUS object with a CBUSConfig object as parameter instead of relying on an "extern" object called "config".