### PR TITLE
Added missing transmitHandler initialization

### DIFF
--- a/src/CBUS2515.cpp
+++ b/src/CBUS2515.cpp
@@ -66,6 +66,7 @@ void CBUS2515::initMembers() {
   eventhandler = NULL;
   eventhandlerex = NULL;
   framehandler = NULL;
+  transmithandler = NULL;
   _csPin = MCP2515_CS;
   _intPin = MCP2515_INT;
   _osc_freq = OSCFREQ;


### PR DESCRIPTION
transmitHandler must be initialized in the initMembers() method otherwise the check for null pointer in sendMessage() method may evaluate to true. Then the code would attempt to dereference and call an invalid function pointer, causing unpredictable behavior.