### PR TITLE
Fixed call to begin() in reset(), now with parameters

### DIFF
--- a/src/CBUS2515.cpp
+++ b/src/CBUS2515.cpp
@@ -66,6 +66,7 @@ void CBUS2515::initMembers() {
   eventhandler = NULL;
   eventhandlerex = NULL;
   framehandler = NULL;
+  _spi = NULL;
   _csPin = MCP2515_CS;
   _intPin = MCP2515_INT;
   _osc_freq = OSCFREQ;
@@ -88,6 +89,7 @@ bool CBUS2515::begin(bool poll, SPIClass & spi)
   _numMsgsSent = 0;
   _numMsgsRcvd = 0;
   _poll = poll;
+  _spi = &spi;
 
   ACAN2515Settings settings(_osc_freq, CANBITRATE);
 
@@ -246,9 +248,15 @@ void CBUS2515::printStatus(void) {
 //
 
 void CBUS2515::reset(void) {
-  canp->end();
-  delete canp;
-  begin();
+  if (canp != nullptr) {
+    canp->end();
+    delete canp;
+    canp = nullptr;
+  }
+
+  if (_spi != nullptr) {
+    begin(_poll, *_spi);
+  }
 }
 
 //

--- a/src/CBUS2515.h
+++ b/src/CBUS2515.h
@@ -100,5 +100,8 @@ private:
 
 #ifdef ARDUINO_ARCH_RP2040
   byte _mosi_pin, _miso_pin, _sck_pin;
+  SPIClassRP2040* _spi;
+#else
+  SPIClass* _spi;
 #endif
 };


### PR DESCRIPTION
In reset() method, the call to begin() was missing the required parameters. Added a private spi pointer to store the SPI instance. Also added some null pointer checks.